### PR TITLE
Removed csv and time from install_requires in setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,11 +21,9 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     requests
-    csv
     bs4
     pandas
     selenium
-    time
     webdriver_manager
 
 [options.packages.find]


### PR DESCRIPTION
Removed csv and time from install_requires in setup.cfg. `pip install .` was resulting in an error because those are included in the standard library and are not found in PyPI.